### PR TITLE
<Request builder>: Support for PostForm

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,6 +37,7 @@ err:= client.ExecuteInto(request, &responseModel)
 Get()
 Head()
 Post()
+PostForm()
 Put()
 Patch()
 Delete()
@@ -80,6 +81,9 @@ WithRequestParams(key string, value string)
 
 // WithRequestBodyParams ...
 WithRequestBodyParams(key string, value interface{})
+
+// WithFormValues ...
+WithFormValues(Key string, value interface{})
 
 // WithURL ...
 WithURL(value string)

--- a/constants.go
+++ b/constants.go
@@ -13,6 +13,11 @@ const (
 	TRACE   = "TRACE"
 )
 
+// Pseudo-constants headers
+var headers = struct {
+	contextType string
+}{"Content-Type"}
+
 // Error
 const (
 	RespDecodeErrorx = "Error while decoding response to into struct"

--- a/request.go
+++ b/request.go
@@ -81,6 +81,11 @@ func (r *Request) WithRequestBodyParams(key string, value interface{}) *Request 
 	return r
 }
 
+// WithFormValues ...
+func (r *Request) WithFormValues(key string, value interface{}) *Request {
+	return r.WithRequestBodyParams(key, value)
+}
+
 // WithURL ...
 func (r *Request) WithURL(value string) *Request {
 	r.url = value
@@ -136,6 +141,12 @@ func (r *Request) Head() *Request {
 func (r *Request) Post() *Request {
 	r.httpVerb = POST
 	return r
+}
+
+// PostForm ...
+func (r *Request) PostForm() *Request {
+	r.httpVerb = POST
+	return r.WithHeaders(headers.contextType, "application/x-www-form-urlencoded")
 }
 
 // Put ...

--- a/request_test.go
+++ b/request_test.go
@@ -90,6 +90,21 @@ func TestWithRequestBodyParams(t *testing.T) {
 		t.Error("TestFailed:TestWithRequestBodyParams")
 	}
 }
+
+func TestWithFormValues(t *testing.T) {
+	key := "testKey"
+	value := "testValue"
+	req := RequestBuilder().WithFormValues(key, value)
+
+	if x, found := req.requestBodyParams[key]; found {
+		if x != value {
+			t.Error("TestFailed:TestWithFormValues")
+		}
+	} else {
+		t.Errorf("TestFailed:TestWithFormValues\n\tgot {%s} {%t}", x, found)
+	}
+}
+
 func TestWithContext(t *testing.T) {
 	ctxTest := context.Background()
 	req := RequestBuilder().WithContext(ctxTest)
@@ -167,6 +182,18 @@ func TestVerbs(t *testing.T) {
 		if req.httpVerb != verb {
 			t.Errorf("TestFailed:TestVerbs {%s}", verb)
 		}
+	}
+}
+
+func TestPostForm(t *testing.T) {
+	req := RequestBuilder().PostForm()
+
+	if req.httpVerb != POST {
+		t.Errorf("TestFailed:TestPostForm want httpVerb {%s}, got {%s}", POST, req.httpVerb)
+	}
+
+	if req.headers[headers.contextType] != "application/x-www-form-urlencoded" {
+		t.Error("TestFailed:TestPostForm")
 	}
 }
 


### PR DESCRIPTION
Added support for PostForm(). Essentially a wrapper around POST()
and adds the correct header. WithFormValues() then adds key-values
to the body.

Fixes: #2

author: ZachPlunkett <Zach13plunkett@gmail.com>